### PR TITLE
Add simple chest boat dupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-﻿# [6b6tCore]
+# 6b6tCore
 
 #### FOLIA ANARCHY CORE
 
 WARNING: JANKY, USE AT YOUR OWN RISK, NO SUPPORT PROVIDED
+
+This fork includes a simple chest boat dupe for Folia 1.20. Use `/dupe` in-game for instructions.
+It also provides basic `/tpa`, `/tphere` and `/tpaccept` commands for teleport requests.

--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -38,6 +38,10 @@ public class LoadFunction {
         Objects.requireNonNull(plugin.getCommand("kill")).setExecutor(new KillCommand());
         Objects.requireNonNull(plugin.getCommand("worldstats")).setExecutor(new WorldStatsCommand());
         Objects.requireNonNull(plugin.getCommand("info")).setExecutor(new InfoCommand());
+        Objects.requireNonNull(plugin.getCommand("dupe")).setExecutor(new DupeCommand());
+        Objects.requireNonNull(plugin.getCommand("tpa")).setExecutor(new TpaCommand());
+        Objects.requireNonNull(plugin.getCommand("tphere")).setExecutor(new TpHereCommand());
+        Objects.requireNonNull(plugin.getCommand("tpaccept")).setExecutor(new TpAcceptCommand());
     }
     private void loadListeners(){
         // Register Bukkit event listeners
@@ -48,6 +52,7 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new PlayerSendMessage(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerInteraction(), plugin);
         Bukkit.getPluginManager().registerEvents(new BlockPluginsCommand(), plugin);
+        Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(60), plugin);
     }
 
     private void loadSqlite(){

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/DupeCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/DupeCommand.java
@@ -1,0 +1,17 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public class DupeCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        String msg = "Place a chest boat, fill it with items, ride it and get out." +
+                " If the boat contains more than five items, every stack will duplicate when you exit.";
+        sender.sendMessage(Configvar.config.getString("prefix") + msg);
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TpAcceptCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TpAcceptCommand.java
@@ -1,0 +1,46 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportManager;
+import com.blbilink.blbilogin.modules.teleport.TeleportManager.TeleportRequest;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class TpAcceptCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) return true;
+        TeleportRequest request = TeleportManager.removeRequest(player);
+        if (request == null) {
+            player.sendMessage("No pending requests");
+            return true;
+        }
+        Player requester = request.requester;
+        if (!requester.isOnline()) {
+            player.sendMessage("Requester is not online");
+            return true;
+        }
+        if (request.here) {
+            // teleport target (player) to requester
+            if (plugin.foliaUtil.isFolia) {
+                player.getScheduler().run(plugin, task -> player.teleportAsync(requester.getLocation()), () -> {});
+            } else {
+                plugin.foliaUtil.runTask(plugin, t -> player.teleport(requester));
+            }
+        } else {
+            // teleport requester to player
+            if (plugin.foliaUtil.isFolia) {
+                requester.getScheduler().run(plugin, task -> requester.teleportAsync(player.getLocation()), () -> {});
+            } else {
+                plugin.foliaUtil.runTask(plugin, t -> requester.teleport(player));
+            }
+        }
+        player.sendMessage("Teleport request accepted");
+        requester.sendMessage(player.getName() + " accepted your request");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TpHereCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TpHereCommand.java
@@ -1,0 +1,29 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class TpHereCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) return true;
+        if (args.length != 1) {
+            player.sendMessage("/tphere <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null || !target.isOnline()) {
+            player.sendMessage("Player not online");
+            return true;
+        }
+        TeleportManager.addRequest(target, player, true);
+        player.sendMessage("Teleport request sent to " + target.getName());
+        target.sendMessage(player.getName() + " wants you to teleport to them. Use /tpaccept to allow.");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TpaCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TpaCommand.java
@@ -1,0 +1,31 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class TpaCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) return true;
+        if (args.length != 1) {
+            player.sendMessage("/tpa <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null || !target.isOnline()) {
+            player.sendMessage("Player not online");
+            return true;
+        }
+        TeleportManager.addRequest(target, player, false);
+        player.sendMessage("Teleport request sent to " + target.getName());
+        target.sendMessage(player.getName() + " wants to teleport to you. Use /tpaccept to allow.");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/dupe/ChestBoatDupeListener.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/dupe/ChestBoatDupeListener.java
@@ -1,0 +1,46 @@
+package com.blbilink.blbilogin.modules.dupe;
+
+import org.bukkit.Material;
+import org.bukkit.entity.ChestBoat;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.vehicle.VehicleExitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class ChestBoatDupeListener implements Listener {
+    private final Map<UUID, Long> cooldowns = new HashMap<>();
+    private final long cooldownMillis;
+
+    public ChestBoatDupeListener(long cooldownSeconds) {
+        this.cooldownMillis = cooldownSeconds * 1000L;
+    }
+
+    @EventHandler
+    public void onVehicleExit(VehicleExitEvent event) {
+        if (!(event.getExited() instanceof Player player)) return;
+        if (!(event.getVehicle() instanceof ChestBoat chestBoat)) return;
+
+        Inventory inv = chestBoat.getInventory();
+        List<ItemStack> items = new ArrayList<>();
+        for (ItemStack item : inv.getContents()) {
+            if (item != null && item.getType() != Material.AIR) {
+                items.add(item);
+            }
+        }
+
+        if (items.size() <= 5) return;
+
+        long last = cooldowns.getOrDefault(player.getUniqueId(), 0L);
+        long now = System.currentTimeMillis();
+        if (now - last < cooldownMillis) return;
+
+        for (ItemStack item : items) {
+            player.getWorld().dropItemNaturally(player.getLocation(), item.clone());
+        }
+        cooldowns.put(player.getUniqueId(), now);
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/teleport/TeleportManager.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/teleport/TeleportManager.java
@@ -1,0 +1,28 @@
+package com.blbilink.blbilogin.modules.teleport;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TeleportManager {
+    public static class TeleportRequest {
+        public final Player requester;
+        public final boolean here;
+        public TeleportRequest(Player requester, boolean here) {
+            this.requester = requester;
+            this.here = here;
+        }
+    }
+
+    private static final Map<UUID, TeleportRequest> requests = new ConcurrentHashMap<>();
+
+    public static void addRequest(Player target, Player requester, boolean here) {
+        requests.put(target.getUniqueId(), new TeleportRequest(requester, here));
+    }
+
+    public static TeleportRequest removeRequest(Player target) {
+        return requests.remove(target.getUniqueId());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,3 +31,15 @@ commands:
     description: "Show world statistics"
   info:
     description: "Alias of worldstats"
+  dupe:
+    description: "Explains the chest boat dupe"
+    usage: /dupe
+  tpa:
+    description: "Request to teleport to a player"
+    usage: /tpa <player>
+  tphere:
+    description: "Request a player to teleport to you"
+    usage: /tphere <player>
+  tpaccept:
+    description: "Accept a teleport request"
+    usage: /tpaccept


### PR DESCRIPTION
## Summary
- add `/dupe` command and implementation
- spawn item dupe when leaving a chest boat with items
- register command and listener
- document dupe usage in README

## Testing
- `./gradlew build` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b091efe14832a8460f90348661439