### PR TITLE
Improve dupe and add teleport commands

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -39,6 +39,9 @@ public class LoadFunction {
         Objects.requireNonNull(plugin.getCommand("worldstats")).setExecutor(new WorldStatsCommand());
         Objects.requireNonNull(plugin.getCommand("info")).setExecutor(new InfoCommand());
         Objects.requireNonNull(plugin.getCommand("dupe")).setExecutor(new DupeCommand());
+        Objects.requireNonNull(plugin.getCommand("tpa")).setExecutor(new TpaCommand());
+        Objects.requireNonNull(plugin.getCommand("tphere")).setExecutor(new TphereCommand());
+        Objects.requireNonNull(plugin.getCommand("tpaccept")).setExecutor(new TpacceptCommand());
     }
     private void loadListeners(){
         // Register Bukkit event listeners

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TpaCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TpaCommand.java
@@ -1,0 +1,34 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportRequestManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class TpaCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage("/tpa <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            player.sendMessage("Player not found");
+            return true;
+        }
+        TeleportRequestManager.addRequest(player.getUniqueId(), target.getUniqueId(), true);
+        player.sendMessage("Teleport request sent to " + target.getName());
+        target.sendMessage(player.getName() + " has requested to teleport to you. Type /tpaccept to accept.");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TpacceptCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TpacceptCommand.java
@@ -1,0 +1,57 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportRequestManager;
+import com.blbilink.blbilogin.modules.teleport.TeleportRequestManager.TeleportRequest;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class TpacceptCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command");
+            return true;
+        }
+
+        TeleportRequest req = TeleportRequestManager.getRequest(player.getUniqueId());
+        if (req == null) {
+            player.sendMessage("No pending teleport requests");
+            return true;
+        }
+
+        Player requester = Bukkit.getPlayer(req.requester);
+        if (requester == null) {
+            player.sendMessage("Requester is not online");
+            TeleportRequestManager.removeRequest(player.getUniqueId());
+            return true;
+        }
+
+        if (req.toTarget) {
+            Location dest = player.getLocation();
+            if (plugin.foliaUtil.isFolia) {
+                requester.getScheduler().run(plugin, task -> requester.teleportAsync(dest), () -> {});
+            } else {
+                plugin.foliaUtil.runTask(plugin, t -> requester.teleport(dest));
+            }
+        } else {
+            Location dest = requester.getLocation();
+            if (plugin.foliaUtil.isFolia) {
+                player.getScheduler().run(plugin, task -> player.teleportAsync(dest), () -> {});
+            } else {
+                plugin.foliaUtil.runTask(plugin, t -> player.teleport(dest));
+            }
+        }
+
+        TeleportRequestManager.removeRequest(player.getUniqueId());
+        player.sendMessage("Teleport request accepted");
+        requester.sendMessage(player.getName() + " accepted your teleport request");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/TphereCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/TphereCommand.java
@@ -1,0 +1,34 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.modules.teleport.TeleportRequestManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class TphereCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage("/tphere <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            player.sendMessage("Player not found");
+            return true;
+        }
+        TeleportRequestManager.addRequest(player.getUniqueId(), target.getUniqueId(), false);
+        player.sendMessage("Teleport request sent to " + target.getName());
+        target.sendMessage(player.getName() + " has requested you teleport to them. Type /tpaccept to accept.");
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/dupe/ChestBoatDupeListener.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/dupe/ChestBoatDupeListener.java
@@ -25,21 +25,17 @@ public class ChestBoatDupeListener implements Listener {
         if (!(event.getVehicle() instanceof ChestBoat chestBoat)) return;
 
         Inventory inv = chestBoat.getInventory();
-        List<ItemStack> items = new ArrayList<>();
-        for (ItemStack item : inv.getContents()) {
-            if (item != null && item.getType() != Material.AIR) {
-                items.add(item);
-            }
-        }
-
-        if (items.size() <= 5) return;
 
         long last = cooldowns.getOrDefault(player.getUniqueId(), 0L);
         long now = System.currentTimeMillis();
         if (now - last < cooldownMillis) return;
 
-        ItemStack chosen = items.get(new Random().nextInt(items.size())).clone();
-        player.getWorld().dropItemNaturally(player.getLocation(), chosen);
+        for (ItemStack item : inv.getContents()) {
+            if (item != null && item.getType() != Material.AIR) {
+                player.getWorld().dropItemNaturally(player.getLocation(), item.clone());
+            }
+        }
+
         cooldowns.put(player.getUniqueId(), now);
     }
 }

--- a/src/main/java/com/blbilink/blbilogin/modules/teleport/TeleportRequestManager.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/teleport/TeleportRequestManager.java
@@ -1,0 +1,41 @@
+package com.blbilink.blbilogin.modules.teleport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class TeleportRequestManager {
+    public static class TeleportRequest {
+        public final UUID requester;
+        public final UUID target;
+        public final boolean toTarget;
+        public final long timestamp;
+
+        public TeleportRequest(UUID requester, UUID target, boolean toTarget) {
+            this.requester = requester;
+            this.target = target;
+            this.toTarget = toTarget;
+            this.timestamp = System.currentTimeMillis();
+        }
+    }
+
+    private static final Map<UUID, TeleportRequest> requests = new HashMap<>();
+    private static final long EXPIRATION = 60 * 1000L; // 60 seconds
+
+    public static void addRequest(UUID requester, UUID target, boolean toTarget) {
+        requests.put(target, new TeleportRequest(requester, target, toTarget));
+    }
+
+    public static TeleportRequest getRequest(UUID target) {
+        TeleportRequest req = requests.get(target);
+        if (req != null && System.currentTimeMillis() - req.timestamp <= EXPIRATION) {
+            return req;
+        }
+        requests.remove(target);
+        return null;
+    }
+
+    public static void removeRequest(UUID target) {
+        requests.remove(target);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -34,3 +34,12 @@ commands:
   dupe:
     description: "Explains the chest boat dupe"
     usage: /dupe
+  tpa:
+    description: "Request to teleport to another player"
+    usage: /tpa <player>
+  tphere:
+    description: "Request another player to teleport to you"
+    usage: /tphere <player>
+  tpaccept:
+    description: "Accept a teleport request"
+    usage: /tpaccept


### PR DESCRIPTION
## Summary
- duplicate every item in chest boats when exiting
- add teleport request manager and `/tpa`, `/tphere`, `/tpaccept` commands
- register new commands and update `plugin.yml`

## Testing
- `bash gradlew build` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b0e1635c8832a9e8b3f88021ccf92