### PR TITLE
Fix wither skull explosion radius

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -53,6 +53,7 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new PlayerInteraction(), plugin);
         Bukkit.getPluginManager().registerEvents(new BlockPluginsCommand(), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(60), plugin);
+        Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.WitherSkullExplodeFix(), plugin);
     }
 
     private void loadSqlite(){

--- a/src/main/java/com/blbilink/blbilogin/modules/events/WitherSkullExplodeFix.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/WitherSkullExplodeFix.java
@@ -1,0 +1,18 @@
+package com.blbilink.blbilogin.modules.events;
+
+import org.bukkit.entity.Wither;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+
+public class WitherSkullExplodeFix implements Listener {
+    @EventHandler
+    public void onWitherSkullExplode(EntityExplodeEvent event) {
+        if (event.getEntity() instanceof WitherSkull skull) {
+            if (skull.getShooter() instanceof Wither) {
+                event.setYield(15.0F);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix wither skull explosion radius when shot by a Wither
- register the listener

## Testing
- `./gradlew tasks --all` *(fails: requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_683b4cdd9aec832abd1c72f81d6f1379