### PR TITLE
Add anti-bot chat filter and login captcha

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -8,6 +8,7 @@ import com.blbilink.blbilogin.modules.events.PlayerSendMessage;
 import com.blbilink.blbilogin.modules.events.PlayerUseCommands;
 import com.blbilink.blbilogin.modules.events.PlayerInteraction;
 import com.blbilink.blbilogin.modules.events.BlockPluginsCommand;
+import com.blbilink.blbilogin.modules.events.AntiBotChatListener;
 import com.blbilink.blbilogin.modules.messages.PlayerSender;
 import org.bukkit.Bukkit;
 
@@ -34,6 +35,7 @@ public class LoadFunction {
 
         Objects.requireNonNull(plugin.getCommand("register")).setExecutor(new Register());
         Objects.requireNonNull(plugin.getCommand("login")).setExecutor(new Login());
+        Objects.requireNonNull(plugin.getCommand("captcha")).setExecutor(new CaptchaCommand());
         Objects.requireNonNull(plugin.getCommand("resetpassword")).setExecutor(new ResetPassword());
         Objects.requireNonNull(plugin.getCommand("kill")).setExecutor(new KillCommand());
         Objects.requireNonNull(plugin.getCommand("worldstats")).setExecutor(new WorldStatsCommand());
@@ -50,6 +52,7 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new PlayerUseCommands(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerJoin(BlbiLogin.plugin), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerSendMessage(), plugin);
+        Bukkit.getPluginManager().registerEvents(new AntiBotChatListener(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerInteraction(), plugin);
         Bukkit.getPluginManager().registerEvents(new BlockPluginsCommand(), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(60), plugin);

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/CaptchaCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/CaptchaCommand.java
@@ -1,0 +1,39 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class CaptchaCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.i18n.as("msgCommandOnlyPlayer", true));
+            return true;
+        }
+
+        String code = Configvar.captchaCodes.get(player.getName());
+        if (code == null) {
+            player.sendMessage(plugin.i18n.as("msgCaptchaNone", true));
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(plugin.i18n.as("msgCaptchaUsage", true, code));
+            return true;
+        }
+
+        if (args[0].equals(code)) {
+            Configvar.captchaCodes.remove(player.getName());
+            Configvar.captchaPassed.add(player.getName());
+            player.sendMessage(plugin.i18n.as("msgCaptchaSuccess", true));
+        } else {
+            player.sendMessage(plugin.i18n.as("msgCaptchaFail", true));
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/Login.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/Login.java
@@ -17,6 +17,10 @@ public class Login implements CommandExecutor {
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         Player player = (Player) sender;
         String uuid = player.getUniqueId().toString();
+        if (!Configvar.captchaPassed.contains(player.getName())) {
+            player.sendMessage(plugin.i18n.as("msgCaptchaNotPass", true));
+            return true;
+        }
         if(!Configvar.noLoginPlayerList.contains(sender.getName())){
             player.sendMessage(plugin.i18n.as("msgAlreadyLogin", true,player.getName()));
             return true;

--- a/src/main/java/com/blbilink/blbilogin/modules/events/AntiBotChatListener.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/AntiBotChatListener.java
@@ -1,0 +1,48 @@
+package com.blbilink.blbilogin.modules.events;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class AntiBotChatListener implements Listener {
+    private final Map<String, Set<String>> messageSenders = new HashMap<>();
+    private final Map<String, Long> messageTime = new HashMap<>();
+    private static final long WINDOW_MS = 5000; // 5 seconds
+    private static final int THRESHOLD = 3;
+    private static final Pattern TLD_PATTERN = Pattern.compile("\\.(com|net|org|info|biz|ru|online|site|xyz)", Pattern.CASE_INSENSITIVE);
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onChat(AsyncPlayerChatEvent event) {
+        String msg = event.getMessage().toLowerCase(Locale.ROOT).trim();
+
+        if (TLD_PATTERN.matcher(msg).find()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        cleanOldEntries(now);
+
+        messageSenders.computeIfAbsent(msg, k -> new HashSet<>()).add(event.getPlayer().getName());
+        messageTime.putIfAbsent(msg, now);
+
+        if (messageSenders.get(msg).size() >= THRESHOLD) {
+            event.setCancelled(true);
+        }
+    }
+
+    private void cleanOldEntries(long now) {
+        Iterator<Map.Entry<String, Long>> it = messageTime.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Long> entry = it.next();
+            if (now - entry.getValue() > WINDOW_MS) {
+                it.remove();
+                messageSenders.remove(entry.getKey());
+            }
+        }
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/events/LoginAction.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/LoginAction.java
@@ -18,6 +18,7 @@ public enum LoginAction {
 
     public void loginSuccess(Player player){
         Configvar.noLoginPlayerList.remove(player.getName());
+        Configvar.captchaPassed.remove(player.getName());
         String msgLoginSuccess = plugin.i18n.as("msgLoginSuccess",true,player.getName());
         player.sendMessage(msgLoginSuccess);
         if (Configvar.config.getBoolean("successLoginSendTitle") || Configvar.config.getBoolean("successLoginSendSubTitle")){

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
@@ -6,6 +6,7 @@ import com.blbilink.blbilogin.vars.Configvar;
 import org.blbilink.blbiLibrary.utils.FoliaUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import java.util.Random;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -32,6 +33,7 @@ public class PlayerJoin implements Listener {
         Configvar.originalLocation.put(e.getName(), e.getLocation());
 
         addNoLoginList(e.getPlayer());
+        createCaptcha(e);
         if(!check.isAllowed(e)) {
             teleportLocation(e);
             setFlying(e);
@@ -98,5 +100,11 @@ public class PlayerJoin implements Listener {
                 plugin.foliaUtil.runTask(plugin, task -> player.teleport(loc));
             }
         }
+    }
+
+    private void createCaptcha(Player player) {
+        String code = String.format("%04d", new Random().nextInt(9000) + 1000);
+        Configvar.captchaCodes.put(player.getName(), code);
+        player.sendMessage(plugin.i18n.as("msgCaptchaSend", true, code));
     }
 }

--- a/src/main/java/com/blbilink/blbilogin/vars/Configvar.java
+++ b/src/main/java/com/blbilink/blbilogin/vars/Configvar.java
@@ -14,6 +14,8 @@ public class Configvar {
     public static Map<String, Location> originalLocation = new HashMap<>();
     public static List<String> noLoginPlayerList = new ArrayList<>();
     public static List<String> canFlyingPlayerList = new ArrayList<>();
+    public static Map<String, String> captchaCodes = new HashMap<>();
+    public static List<String> captchaPassed = new ArrayList<>();
     public static FileConfiguration config;
     public static File configFile;
 

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -33,3 +33,9 @@ noRegisterPlayerSendActionBar: "You are currently §cnot registered§f, operatio
 
 successLoginSendTitle: "§a§lLogin Successful"
 successLoginSendSubTitle: "Welcome back: §a%s"
+msgCaptchaSend: "Please solve captcha with /captcha %s"
+msgCaptchaUsage: "Use /captcha <code>, your code is %s"
+msgCaptchaSuccess: "Captcha solved! You may now log in."
+msgCaptchaFail: "§cIncorrect captcha code."
+msgCaptchaNone: "No captcha pending."
+msgCaptchaNotPass: "You must solve the captcha before logging in."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,9 @@ commands:
     description: "Register command"
     usage: /register <password>
     aliases: [reg]
+  captcha:
+    description: "Solve captcha"
+    usage: /captcha <code>
   blbilogin:
     description: "Main plugin command"
     usage: /blbilogin <args>


### PR DESCRIPTION
## Summary
- block spammy messages and .com links with `AntiBotChatListener`
- generate a captcha code on join and add `/captcha` command
- require captcha completion before using `/login`
- update localization and config variables
- wire new command and listener in plugin load logic

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b51684118832abb1a756a3892fab5