### PR TITLE
Delay login prompts so captcha appears first

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/modules/commands/CaptchaCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/CaptchaCommand.java
@@ -1,6 +1,7 @@
 package com.blbilink.blbilogin.modules.commands;
 
 import com.blbilink.blbilogin.vars.Configvar;
+import com.blbilink.blbilogin.modules.messages.PlayerSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -31,6 +32,10 @@ public class CaptchaCommand implements CommandExecutor {
             Configvar.captchaCodes.remove(player.getName());
             Configvar.captchaPassed.add(player.getName());
             player.sendMessage(plugin.i18n.as("msgCaptchaSuccess", true));
+
+            // After captcha is passed, begin sending login prompts so the
+            // player knows to log in.
+            PlayerSender.startLoginPrompts(player);
         } else {
             player.sendMessage(plugin.i18n.as("msgCaptchaFail", true));
         }

--- a/src/main/java/com/blbilink/blbilogin/modules/messages/PlayerSender.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/messages/PlayerSender.java
@@ -44,23 +44,8 @@ public class PlayerSender implements Listener {
     @EventHandler
     public void noLoginPlayerSendTitle(PlayerJoinEvent e) {
         if (!check.isBedrock(e.getPlayer())) {
-            if (Configvar.config.getBoolean("noLoginPlayerSendActionBar") ||
-                    Configvar.config.getBoolean("noLoginPlayerSendTitle") ||
-                    Configvar.config.getBoolean("noLoginPlayerSendSubTitle") ||
-                    Configvar.config.getBoolean("noLoginPlayerSendMessage") ||
-                    Configvar.config.getBoolean("noRegisterPlayerSendTitle") ||
-                    Configvar.config.getBoolean("noRegisterPlayerSendSubTitle") ||
-                    Configvar.config.getBoolean("noRegisterPlayerSendMessage") ||
-                    Configvar.config.getBoolean("noRegisterPlayerSendActionBar")) {
-
-                Player player = e.getPlayer();
-                FoliaUtil.Cancellable task = plugin.foliaUtil.runTaskTimerAsync(plugin, cancellable -> {
-                    if (Configvar.noLoginPlayerList.contains(player.getName())) {
-                        sendPlayerMessages(player);
-                    } else {
-                        cancellable.cancel();
-                    }
-                }, 0L, 60L);
+            if (Configvar.captchaPassed.contains(e.getPlayer().getName())) {
+                startLoginPrompts(e.getPlayer());
             }
         }
     }
@@ -79,6 +64,31 @@ public class PlayerSender implements Listener {
     @EventHandler
     public void onPluginDisable(PluginDisableEvent event) {
         if (event.getPlugin().equals(plugin)) if (timer != null) timer.cancel();
+    }
+
+
+    /**
+     * Begin showing login prompts for the given player. Prompts repeat until
+     * the player successfully logs in, at which point the task cancels itself.
+     */
+    public static void startLoginPrompts(Player player) {
+        if (Configvar.config.getBoolean("noLoginPlayerSendActionBar") ||
+                Configvar.config.getBoolean("noLoginPlayerSendTitle") ||
+                Configvar.config.getBoolean("noLoginPlayerSendSubTitle") ||
+                Configvar.config.getBoolean("noLoginPlayerSendMessage") ||
+                Configvar.config.getBoolean("noRegisterPlayerSendTitle") ||
+                Configvar.config.getBoolean("noRegisterPlayerSendSubTitle") ||
+                Configvar.config.getBoolean("noRegisterPlayerSendMessage") ||
+                Configvar.config.getBoolean("noRegisterPlayerSendActionBar")) {
+
+            plugin.foliaUtil.runTaskTimerAsync(plugin, cancellable -> {
+                if (Configvar.noLoginPlayerList.contains(player.getName())) {
+                    sendPlayerMessages(player);
+                } else {
+                    cancellable.cancel();
+                }
+            }, 20L, 60L); // start shortly after captcha success
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- delay sending login prompts so captcha message doesn't get overshadowed
- only show login prompts once the player solves the captcha

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b5516d488832abde75dfd8e0be5a5