### PR TITLE
Implement basic anti-32k protection

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -7,6 +7,7 @@ import com.blbilink.blbilogin.modules.events.PlayerJoin;
 import com.blbilink.blbilogin.modules.events.PlayerSendMessage;
 import com.blbilink.blbilogin.modules.events.PlayerUseCommands;
 import com.blbilink.blbilogin.modules.events.PlayerInteraction;
+import com.blbilink.blbilogin.modules.events.Anti32kDamage;
 import com.blbilink.blbilogin.modules.events.BlockPluginsCommand;
 import com.blbilink.blbilogin.modules.events.AntiBotChatListener;
 import com.blbilink.blbilogin.modules.messages.PlayerSender;
@@ -55,6 +56,7 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new AntiBotChatListener(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerInteraction(), plugin);
         Bukkit.getPluginManager().registerEvents(new BlockPluginsCommand(), plugin);
+        Bukkit.getPluginManager().registerEvents(new Anti32kDamage(), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(60), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.WitherSkullExplodeFix(), plugin);
     }

--- a/src/main/java/com/blbilink/blbilogin/modules/events/Anti32kDamage.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/Anti32kDamage.java
@@ -1,0 +1,32 @@
+package com.blbilink.blbilogin.modules.events;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class Anti32kDamage implements Listener {
+    private static final double DAMAGE_THRESHOLD = 100.0;
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player victim)) return;
+
+        if (!Configvar.config.getBoolean("disable32kDamage")) return;
+
+        if (event.getDamager() instanceof Player attacker) {
+            ItemStack item = attacker.getInventory().getItemInMainHand();
+            if (item != null && item.getEnchantments().values().stream().anyMatch(l -> l > 1000)) {
+                event.setCancelled(true);
+                attacker.sendMessage(Configvar.config.getString("prefix") + "32k weapons are disabled against players.");
+                return;
+            }
+        }
+
+        if (event.getDamage() > DAMAGE_THRESHOLD) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,6 +38,9 @@ playerJoinAutoTeleportToSavedLocation_AutoBack: false
 # Whether to use SQLite database to store player information
 useSqlite: true
 
+# Whether to block damage from high-level enchantments (e.g. Sharpness 32767)
+disable32kDamage: true
+
 # 未登录玩家行为限制设置
 # Behavior restrictions for unlogged players
 # 是否限制未登录玩家移动


### PR DESCRIPTION
## Summary
- add an `Anti32kDamage` listener that blocks extremely enchanted weapons
- register listener in `LoadFunction`
- provide `disable32kDamage` setting

## Testing
- `./gradlew build` *(fails: could not download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_683b60b3d8bc832a99f2ba0061e9aaef