### PR TITLE
Fix captcha accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Key settings:
 - `noLoginPlayer*`: Full control over what unlogged players can/can’t do.
 - `bedrock`: Bedrock/Floodgate login support and auto-login options.
 
+`/captcha` is automatically whitelisted so new players can solve the captcha even when other commands are blocked.
+
 Database is stored in `players.db`.
 
 ---

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerUseCommands.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerUseCommands.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class PlayerUseCommands implements Listener {
     @EventHandler
     public void onPlayerCommandSend(PlayerCommandPreprocessEvent e) {
-        List<String> cmds = new ArrayList<>(List.of("/login", "/l", "/reg", "/register", "/kill", "/suicide"));
+        List<String> cmds = new ArrayList<>(List.of("/login", "/l", "/reg", "/register", "/captcha", "/kill", "/suicide"));
         cmds.addAll(Configvar.config.getStringList("noLoginPlayerAllowUseCommand"));
         String message = e.getMessage();
         boolean isAllowedCommand = false;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,6 +52,7 @@ noLoginPlayerCantUseCommand: true
 # 未登录玩家允许使用的命令列表
 # List of commands allowed for unlogged players
 noLoginPlayerAllowUseCommand:
+  - "/captcha"
   - "/example"
 # 是否使未登录玩家无敌（不受伤害）
 # Whether to make unlogged players invulnerable (immune to damage)


### PR DESCRIPTION
## Summary
- allow `/captcha` command for unlogged players
- document that captcha is whitelisted
- whitelist `/captcha` by default in config

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b73f38ed8832a96df4439c207e3f9