### PR TITLE
Add random prefixes to captcha codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 🔧 Key Features
 
 - ✅ SQLite-based **/register** and **/login** system with optional Bedrock support via Floodgate.
-- ✅ Text-based **captcha** to block bots/skids on first join.
+- ✅ Text-based **captcha** to block bots/skids on first join. Codes include random letter prefixes.
 - ✅ Crossplay-friendly login forms (optional).
 - ✅ `/tpa`, `/tpaccept`, `/tphere` for basic teleportation without home/warp BS.
 - ✅ Solo chest boat dupe with `/dupe` command explaining how to abuse it.
@@ -56,6 +56,8 @@ Key settings:
 - `disable32kDamage`: Cancels damage from OP weapons (Enchants > 1000).
 - `noLoginPlayer*`: Full control over what unlogged players can/can’t do.
 - `bedrock`: Bedrock/Floodgate login support and auto-login options.
+
+`/captcha` is automatically whitelisted so new players can solve the captcha even when other commands are blocked.
 
 Database is stored in `players.db`.
 

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
@@ -103,7 +103,15 @@ public class PlayerJoin implements Listener {
     }
 
     private void createCaptcha(Player player) {
-        String code = String.format("%04d", new Random().nextInt(9000) + 1000);
+        Random random = new Random();
+        String digits = String.format("%04d", random.nextInt(9000) + 1000);
+        StringBuilder prefix = new StringBuilder();
+        for (int i = 0; i < 3; i++) {
+            char letter = (char) ('A' + random.nextInt(26));
+            prefix.append(letter);
+        }
+
+        String code = prefix + digits;
         Configvar.captchaCodes.put(player.getName(), code);
         player.sendMessage(plugin.i18n.as("msgCaptchaSend", true, code));
     }

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerUseCommands.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerUseCommands.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class PlayerUseCommands implements Listener {
     @EventHandler
     public void onPlayerCommandSend(PlayerCommandPreprocessEvent e) {
-        List<String> cmds = new ArrayList<>(List.of("/login", "/l", "/reg", "/register", "/kill", "/suicide"));
+        List<String> cmds = new ArrayList<>(List.of("/login", "/l", "/reg", "/register", "/captcha", "/kill", "/suicide"));
         cmds.addAll(Configvar.config.getStringList("noLoginPlayerAllowUseCommand"));
         String message = e.getMessage();
         boolean isAllowedCommand = false;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,6 +52,7 @@ noLoginPlayerCantUseCommand: true
 # 未登录玩家允许使用的命令列表
 # List of commands allowed for unlogged players
 noLoginPlayerAllowUseCommand:
+  - "/captcha"
   - "/example"
 # 是否使未登录玩家无敌（不受伤害）
 # Whether to make unlogged players invulnerable (immune to damage)


### PR DESCRIPTION
## Summary
- Captcha codes now include three random letter prefixes
- Updated README noting random prefixes

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b73f38ed8832a96df4439c207e3f9