### PR TITLE
Add spam protection and config options

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -52,7 +52,8 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new PlayerSendMessage(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerInteraction(), plugin);
         Bukkit.getPluginManager().registerEvents(new BlockPluginsCommand(), plugin);
-        Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(60), plugin);
+        Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(0), plugin);
+        Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.SpamProtection(), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.WitherSkullExplodeFix(), plugin);
     }
 

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/DupeCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/DupeCommand.java
@@ -10,7 +10,7 @@ public class DupeCommand implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         String msg = "Place a chest boat, fill it with items, ride it and exit." +
-                " A random stack will drop when you get out if the boat has more than 5 items.";
+                " All items will duplicate with 100% success and there is no cooldown.";
         sender.sendMessage(Configvar.config.getString("prefix") + msg);
         return true;
     }

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerInteraction.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerInteraction.java
@@ -37,13 +37,15 @@ public class PlayerInteraction implements Listener {
             return;
         }
 
-        // Block 32k weapons from damaging players
-        var item = attacker.getInventory().getItemInMainHand();
-        if (item != null && item.getEnchantments().values().stream().anyMatch(l -> l > 1000)) {
-            if (victim instanceof Player) {
-                ev.setCancelled(true);
-                attacker.sendMessage(Configvar.config.getString("prefix") + "32k weapons are disabled against players.");
-                return;
+        // Block 32k weapons from damaging players if enabled
+        if (Configvar.config.getBoolean("anti32kPatch")) {
+            var item = attacker.getInventory().getItemInMainHand();
+            if (item != null && item.getEnchantments().values().stream().anyMatch(l -> l > 1000)) {
+                if (victim instanceof Player) {
+                    ev.setCancelled(true);
+                    attacker.sendMessage(Configvar.config.getString("prefix") + "32k weapons are disabled against players.");
+                    return;
+                }
             }
         }
 

--- a/src/main/java/com/blbilink/blbilogin/modules/events/SpamProtection.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/SpamProtection.java
@@ -1,0 +1,33 @@
+package com.blbilink.blbilogin.modules.events;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.blbilink.blbilogin.BlbiLogin.plugin;
+
+public class SpamProtection implements Listener {
+    private final Map<UUID, Long> lastMessage = new HashMap<>();
+
+    @EventHandler
+    public void onChat(AsyncPlayerChatEvent event) {
+        long interval = Configvar.config.getLong("spamProtectionCooldown");
+        if (interval <= 0) return;
+
+        Player player = event.getPlayer();
+        long now = System.currentTimeMillis();
+        long last = lastMessage.getOrDefault(player.getUniqueId(), 0L);
+        if (now - last < interval) {
+            event.setCancelled(true);
+            player.sendMessage(plugin.i18n.as("msgSpamDetected", true, player.getName()));
+            return;
+        }
+        lastMessage.put(player.getUniqueId(), now);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,6 +38,14 @@ playerJoinAutoTeleportToSavedLocation_AutoBack: false
 # Whether to use SQLite database to store player information
 useSqlite: true
 
+# 是否启用反32k伤害补丁
+# Enable anti-32k damage patch
+anti32kPatch: true
+
+# 简单的聊天刷屏防护，单位毫秒，设为0关闭
+# Simple chat spam protection interval in milliseconds, set to 0 to disable
+spamProtectionCooldown: 1000
+
 # 未登录玩家行为限制设置
 # Behavior restrictions for unlogged players
 # 是否限制未登录玩家移动

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -33,3 +33,4 @@ noRegisterPlayerSendActionBar: "You are currently §cnot registered§f, operatio
 
 successLoginSendTitle: "§a§lLogin Successful"
 successLoginSendSubTitle: "Welcome back: §a%s"
+msgSpamDetected: "Please slow down, do not spam the chat."


### PR DESCRIPTION
## Summary
- implement optional anti-32k patch toggle
- add chat spam protection listener
- update dupe command help text
- register new listener and remove dupe cooldown
- add config options and language string

## Testing
- `./gradlew build` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b7bd078f0832a9b4abaed5a7bf8a4