### PR TITLE
Fix anti 32k patch check for 255 enchants

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerInteraction.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerInteraction.java
@@ -37,10 +37,11 @@ public class PlayerInteraction implements Listener {
             return;
         }
 
-        // Block 32k weapons from damaging players if enabled
+        // Block weapons with enchant levels higher than normally allowed
         if (Configvar.config.getBoolean("anti32kPatch")) {
             var item = attacker.getInventory().getItemInMainHand();
-            if (item != null && item.getEnchantments().values().stream().anyMatch(l -> l > 1000)) {
+            if (item != null && item.getEnchantments().entrySet().stream()
+                    .anyMatch(e -> e.getValue() > e.getKey().getMaxLevel())) {
                 if (victim instanceof Player) {
                     ev.setCancelled(true);
                     attacker.sendMessage(Configvar.config.getString("prefix") + "32k weapons are disabled against players.");


### PR DESCRIPTION
## Summary
- update anti-32k check to consider enchantment max levels

## Testing
- `gradlew tasks` *(fails: Could not download due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683dc39b9c34832abb6944c041eaf393