### PR TITLE
Add antiillegal stubs

### DIFF
--- a/src/main/java/me/txmc/core/Main.java
+++ b/src/main/java/me/txmc/core/Main.java
@@ -1,0 +1,34 @@
+package me.txmc.core;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Simplified main plugin class for 6b6t functionality stubs.
+ */
+public class Main extends JavaPlugin {
+    private static Main instance;
+
+    @Override
+    public void onEnable() {
+        instance = this;
+    }
+
+    @Override
+    public void onDisable() {
+    }
+
+    public static Main getInstance() {
+        return instance;
+    }
+
+    public FileConfiguration getSectionConfig(Section section) {
+        return getConfig();
+    }
+
+    public void register(org.bukkit.event.Listener... listeners) {
+        for (org.bukkit.event.Listener listener : listeners) {
+            getServer().getPluginManager().registerEvents(listener, this);
+        }
+    }
+}

--- a/src/main/java/me/txmc/core/Section.java
+++ b/src/main/java/me/txmc/core/Section.java
@@ -1,0 +1,11 @@
+package me.txmc.core;
+
+/**
+ * Minimal section interface used for modular systems in 6b6t.
+ */
+public interface Section {
+    void enable();
+    void disable();
+    void reloadConfig();
+    String getName();
+}

--- a/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
+++ b/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
@@ -1,0 +1,95 @@
+package me.txmc.core.antiillegal;
+
+import me.txmc.core.Main;
+import me.txmc.core.Section;
+import me.txmc.core.antiillegal.check.Check;
+import me.txmc.core.antiillegal.check.checks.*;
+import me.txmc.core.antiillegal.listeners.*;
+import me.txmc.core.util.GlobalUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.Cancellable;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * Core of the anti illegal system for 6b6t.
+ */
+public class AntiIllegalMain implements Section {
+    private final Main plugin;
+    private final List<Check> checks = new ArrayList<>(Arrays.asList(
+            new OverStackCheck(),
+            new DurabilityCheck(),
+            new AttributeCheck(),
+            //new LoreCheck(),
+            new EnchantCheck(),
+            new PotionCheck(),
+            new BookCheck(),
+            new IllegalItemCheck()
+    ));
+
+    private ConfigurationSection config;
+
+    public AntiIllegalMain(Main plugin) {
+        this.plugin = plugin;
+    }
+
+    public Main getPlugin() {
+        return plugin;
+    }
+
+    public List<Check> getChecks() {
+        return checks;
+    }
+
+    public ConfigurationSection config() {
+        return config;
+    }
+
+    @Override
+    public void enable() {
+
+        config = plugin.getSectionConfig(this);
+        checks.add(new NameCheck(config));
+//        checks.add(new ItemSizeCheck());
+
+        plugin.register(new PlayerListeners(this), new MiscListeners(this), new InventoryListeners(this), new AttackListener(), new StackedTotemsListener());
+        if(plugin.getConfig().getBoolean("AntiIllegal.EnableIllegalBlocksCleaner", true)) plugin.register(new IllegalBlocksCleaner());
+    }
+
+    @Override
+    public void disable() {
+
+    }
+
+    @Override
+    public void reloadConfig() {
+        config = plugin.getSectionConfig(this);
+    }
+
+    @Override
+    public String getName() {
+        return "AntiIllegal";
+    }
+
+    public void checkFixItem(ItemStack item, Cancellable cancellable) {
+        if (item == null || item.getType() == Material.AIR) return;
+        for (Check check : checks) {
+            if (check.shouldCheck(item) && check.check(item)) {
+                if (cancellable != null && !cancellable.isCancelled()) cancellable.setCancelled(true);
+                //GlobalUtils.log(Level.INFO, "Item %s failed the %s check and has been fixed.", getItemName(item), check.getClass().getSimpleName());
+                check.fix(item);
+                item.setItemMeta(item.getItemMeta());
+            }
+        }
+    }
+    private String getItemName(ItemStack itemStack) {
+        return (itemStack.hasItemMeta() && itemStack.getItemMeta().hasDisplayName()) ?
+                GlobalUtils.getStringContent(itemStack.getItemMeta().getDisplayName()) :
+                itemStack.getType().name();
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/Check.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/Check.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Base interface for item checks in 6b6t anti-illegal.
+ */
+public interface Check {
+    boolean check(ItemStack item);
+
+    boolean shouldCheck(ItemStack item);
+
+    void fix(ItemStack item);
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/AttributeCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/AttributeCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for AttributeCheck */
+public class AttributeCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/BookCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/BookCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for BookCheck */
+public class BookCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/DurabilityCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/DurabilityCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for DurabilityCheck */
+public class DurabilityCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/EnchantCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/EnchantCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for EnchantCheck */
+public class EnchantCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
@@ -1,0 +1,27 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Check for illegal NBT data on items.
+ * <p>
+ * Part of the 6b6t anti-illegal system.
+ * </p>
+ */
+public class IllegalDataCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldCheck(ItemStack item) {
+        return false;
+    }
+
+    @Override
+    public void fix(ItemStack item) {
+        // no-op
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalItemCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalItemCheck.java
@@ -1,0 +1,60 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.Main;
+import me.txmc.core.antiillegal.check.Check;
+import me.txmc.core.util.GlobalUtils;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+import java.util.logging.Level;
+
+/**
+ * Checks and removes completely illegal items for 6b6t.
+ */
+public class IllegalItemCheck implements Check {
+    private final HashSet<Material> illegals;
+
+    public IllegalItemCheck() {
+        illegals = parseConfig();
+    }
+
+    @Override
+    public boolean check(ItemStack item) {
+        return illegals.contains(item.getType()); // O(1) thanks HashSet
+    }
+
+    @Override
+    public boolean shouldCheck(ItemStack item) {
+        return true;
+    }
+
+    @Override
+    public void fix(ItemStack item) {
+        item.setAmount(0);
+    }
+
+    private HashSet<Material> parseConfig() {
+        List<String> materialNames = Arrays.stream(Material.values()).map(Material::name).toList();
+        List<String> strList = Main.getInstance().getConfig().getStringList("AntiIllegal.IllegalItems");
+        List<Material> output = new ArrayList<>();
+        for (String raw : strList) {
+            try {
+                raw = raw.toUpperCase();
+                if (raw.contains("*")) {
+                    raw = raw.replace("*", "");
+                    for (String materialName : materialNames) {
+                        if (materialName.contains(raw)) output.add(Material.getMaterial(materialName));
+                    }
+                    continue;
+                }
+                Material material = Material.getMaterial(raw);
+                if (material == null) throw new EnumConstantNotPresentException(Material.class, raw);
+                output.add(material);
+            } catch (EnumConstantNotPresentException | IllegalArgumentException e) {
+                GlobalUtils.log(Level.WARNING, "&3Unknown material&r&a %s&r&3 in blocks section of the config", raw);
+            }
+        }
+        return new HashSet<>(output);
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
@@ -1,0 +1,16 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for NameCheck */
+public class NameCheck implements Check {
+    public NameCheck(ConfigurationSection section) {}
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/OverStackCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/OverStackCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for OverStackCheck */
+public class OverStackCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/PotionCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/PotionCheck.java
@@ -1,0 +1,14 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.inventory.ItemStack;
+
+/** Placeholder for PotionCheck */
+public class PotionCheck implements Check {
+    @Override
+    public boolean check(ItemStack item) { return false; }
+    @Override
+    public boolean shouldCheck(ItemStack item) { return false; }
+    @Override
+    public void fix(ItemStack item) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/AttackListener.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/AttackListener.java
@@ -1,0 +1,21 @@
+package me.txmc.core.antiillegal.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+/**
+ * Listener that prevents players from dealing excessive damage.
+ * Part of the 6b6t anti-illegal suite.
+ */
+public class AttackListener implements Listener {
+    @EventHandler
+    public void onAttack(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player)) return;
+        if (event.getDamage() > 30D) {
+            event.setCancelled(true);
+            ((Player) event.getDamager()).damage(event.getDamage());
+        }
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
@@ -1,0 +1,79 @@
+package me.txmc.core.antiillegal.listeners;
+
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+import static java.lang.Math.abs;
+
+/**
+ * Listener that cleans illegal blocks in chunks when they are loaded.
+ * <p>
+ * Rebranded for 6b6t.
+ * </p>
+ */
+public class IllegalBlocksCleaner implements Listener {
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent event) {
+        if (event.isNewChunk()) return;
+
+        Chunk chunk = event.getChunk();
+        if (abs(chunk.getX()) >= 1000000 || abs(chunk.getZ()) >= 1000000) return;
+
+        int yUpperLimit = event.getWorld().getMaxHeight();
+        int yLowerLimit = event.getWorld().getMinHeight();
+
+        World.Environment worldEnv = event.getWorld().getEnvironment();
+
+        if (worldEnv == World.Environment.NETHER) {
+            yUpperLimit = 127;
+        }
+
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = yLowerLimit; y < yUpperLimit; y++) {
+                    Block block = chunk.getBlock(x, y, z);
+                    Material type = block.getType();
+
+                    // Nether rules
+                    if (worldEnv == World.Environment.NETHER && (
+                            type == Material.END_PORTAL_FRAME ||
+                            type == Material.REINFORCED_DEEPSLATE ||
+                            type == Material.BARRIER ||
+                            type == Material.LIGHT ||
+                            type == Material.END_PORTAL ||
+                            (type == Material.BEDROCK && y >= yLowerLimit + 5 && y <= yUpperLimit - 5))) {
+                        block.setType(Material.AIR);
+                    }
+
+                    // Overworld rules
+                    if (worldEnv == World.Environment.NORMAL && (
+                            type == Material.END_PORTAL_FRAME ||
+                            type == Material.REINFORCED_DEEPSLATE ||
+                            type == Material.BARRIER ||
+                            type == Material.LIGHT ||
+                            type == Material.END_PORTAL ||
+                            (type == Material.BEDROCK && y >= yLowerLimit + 5))) {
+                        block.setType(Material.AIR);
+                    }
+
+                    // End rules
+                    if (worldEnv == World.Environment.THE_END && (
+                            type == Material.END_PORTAL_FRAME ||
+                            type == Material.REINFORCED_DEEPSLATE ||
+                            type == Material.BARRIER ||
+                            type == Material.LIGHT ||
+                            type == Material.END_PORTAL ||
+                            type == Material.BEDROCK)) {
+                        block.setType(Material.AIR);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
@@ -1,0 +1,9 @@
+package me.txmc.core.antiillegal.listeners;
+
+import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.Listener;
+
+/** Placeholder for InventoryListeners */
+public class InventoryListeners implements Listener {
+    public InventoryListeners(AntiIllegalMain main) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/MiscListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/MiscListeners.java
@@ -1,0 +1,9 @@
+package me.txmc.core.antiillegal.listeners;
+
+import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.Listener;
+
+/** Placeholder for MiscListeners */
+public class MiscListeners implements Listener {
+    public MiscListeners(AntiIllegalMain main) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/PlayerListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/PlayerListeners.java
@@ -1,0 +1,9 @@
+package me.txmc.core.antiillegal.listeners;
+
+import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.Listener;
+
+/** Placeholder for PlayerListeners */
+public class PlayerListeners implements Listener {
+    public PlayerListeners(AntiIllegalMain main) {}
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/StackedTotemsListener.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/StackedTotemsListener.java
@@ -1,0 +1,6 @@
+package me.txmc.core.antiillegal.listeners;
+
+import org.bukkit.event.Listener;
+
+/** Placeholder for StackedTotemsListener */
+public class StackedTotemsListener implements Listener {}

--- a/src/main/java/me/txmc/core/util/GlobalUtils.java
+++ b/src/main/java/me/txmc/core/util/GlobalUtils.java
@@ -1,0 +1,19 @@
+package me.txmc.core.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utility class providing basic helpers for 6b6t.
+ */
+public class GlobalUtils {
+    private static final Logger LOGGER = Logger.getLogger("6b6tCore");
+
+    public static void log(Level level, String message, Object... args) {
+        LOGGER.log(level, String.format(message, args));
+    }
+
+    public static String getStringContent(String input) {
+        return input;
+    }
+}


### PR DESCRIPTION
## Summary
- add AntiIllegal system skeleton under new `me.txmc.core` package
- include listeners and checks rebranded for 6b6t
- provide placeholder classes to allow compilation
- drop Lombok usage and adjust item display name retrieval

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683dc77a3cf8832aba0858371a183552