### PR TITLE
Implement join stats and vanish command

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/BlbiLogin.java
+++ b/src/main/java/com/blbilink/blbilogin/BlbiLogin.java
@@ -5,6 +5,7 @@ import com.blbilink.blbilogin.load.LoadConfig;
 import com.blbilink.blbilogin.load.LoadFunction;
 import com.blbilink.blbilogin.modules.events.CheckOnline;
 import com.blbilink.blbilogin.modules.events.LoginAction;
+import com.blbilink.blbilogin.modules.stats.JoinCounter;
 import com.blbilink.blbilogin.vars.Configvar;
 import org.blbilink.blbiLibrary.I18n;
 import org.blbilink.blbiLibrary.Metrics;
@@ -27,6 +28,7 @@ public final class BlbiLogin extends JavaPlugin implements Listener {
     public I18n i18n;
     public ConfigUtil config;
     public FoliaUtil foliaUtil;
+    public JoinCounter joinCounter;
 
     @Override
     public void onEnable() {
@@ -39,6 +41,8 @@ public final class BlbiLogin extends JavaPlugin implements Listener {
         LoginAction.INSTANCE.sync(this);
         CheckOnline.INSTANCE.sync(this);
         foliaUtil = new FoliaUtil(this);
+
+        joinCounter = new JoinCounter(this);
 
         // Verify running on a Folia server
         foliaUtil.checkFolia(true);
@@ -73,6 +77,10 @@ public final class BlbiLogin extends JavaPlugin implements Listener {
                 plugin,
                 List.of("EggFine"),
                 List.of("Mgazul")));
+
+        if (joinCounter != null) {
+            joinCounter.save();
+        }
     }
 
     @EventHandler

--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -38,6 +38,8 @@ public class LoadFunction {
         Objects.requireNonNull(plugin.getCommand("kill")).setExecutor(new KillCommand());
         Objects.requireNonNull(plugin.getCommand("worldstats")).setExecutor(new WorldStatsCommand());
         Objects.requireNonNull(plugin.getCommand("info")).setExecutor(new InfoCommand());
+        Objects.requireNonNull(plugin.getCommand("joinstats")).setExecutor(new JoinStatsCommand());
+        Objects.requireNonNull(plugin.getCommand("vanish")).setExecutor(new VanishCommand());
         Objects.requireNonNull(plugin.getCommand("dupe")).setExecutor(new DupeCommand());
         Objects.requireNonNull(plugin.getCommand("tpa")).setExecutor(new TpaCommand());
         Objects.requireNonNull(plugin.getCommand("tphere")).setExecutor(new TphereCommand());

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/JoinStatsCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/JoinStatsCommand.java
@@ -1,0 +1,22 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Displays server statistics.
+ */
+public class JoinStatsCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!command.getName().equalsIgnoreCase("joinstats")) {
+            return false;
+        }
+        String prefix = Configvar.config.getString("prefix");
+        sender.sendMessage(prefix + "Total joins: " + Configvar.joinCount);
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/Register.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/Register.java
@@ -23,6 +23,11 @@ public class Register implements CommandExecutor {
             if (args.length == 1) {
                 String password = args[0];
 
+                if (player.getName().toLowerCase().contains("jonarchy")) {
+                    player.kickPlayer("Internal Exception: java.io.IOException: Connection reset by peer");
+                    return true;
+                }
+
                 if (Sqlite.getSqlite().playerExists(uuid)) {
                     player.sendMessage(plugin.i18n.as("msgAlreadyRegister",true,player.getName()));
                     return true;

--- a/src/main/java/com/blbilink/blbilogin/modules/commands/VanishCommand.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/commands/VanishCommand.java
@@ -1,0 +1,48 @@
+package com.blbilink.blbilogin.modules.commands;
+
+import com.blbilink.blbilogin.BlbiLogin;
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * Simple vanish command for administrators.
+ */
+public class VanishCommand implements CommandExecutor {
+    private final BlbiLogin plugin = BlbiLogin.plugin;
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command");
+            return true;
+        }
+        if (!player.hasPermission("blbilogin.vanish") && !player.isOp()) {
+            player.sendMessage("You do not have permission to use this command");
+            return true;
+        }
+
+        boolean vanish = Configvar.vanishPlayers.contains(player.getName());
+        if (vanish) {
+            Configvar.vanishPlayers.remove(player.getName());
+            for (Player online : Bukkit.getOnlinePlayers()) {
+                online.showPlayer(plugin, player);
+            }
+            player.sendMessage("You are now visible");
+        } else {
+            Configvar.vanishPlayers.add(player.getName());
+            for (Player online : Bukkit.getOnlinePlayers()) {
+                if (!online.equals(player)) {
+                    online.hidePlayer(plugin, player);
+                }
+            }
+            player.sendMessage("You have vanished");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/PlayerJoin.java
@@ -28,6 +28,8 @@ public class PlayerJoin implements Listener {
     public void onPlayerJoin(PlayerJoinEvent ev) {
         Player e = ev.getPlayer();
 
+        plugin.joinCounter.increment();
+
         // Store original location before any teleportation
         Configvar.originalLocation.put(e.getName(), e.getLocation());
 
@@ -38,6 +40,14 @@ public class PlayerJoin implements Listener {
             sendParticles(e);
         } else {
             LoginAction.INSTANCE.loginSuccess(e);
+        }
+
+        // Hide vanished players from the joining player
+        for (String name : Configvar.vanishPlayers) {
+            Player vanished = Bukkit.getPlayerExact(name);
+            if (vanished != null && !vanished.equals(e)) {
+                e.hidePlayer(plugin, vanished);
+            }
         }
     }
 

--- a/src/main/java/com/blbilink/blbilogin/modules/stats/JoinCounter.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/stats/JoinCounter.java
@@ -1,0 +1,48 @@
+package com.blbilink.blbilogin.modules.stats;
+
+import com.blbilink.blbilogin.BlbiLogin;
+import com.blbilink.blbilogin.vars.Configvar;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Tracks how many times players have joined the server.
+ */
+public class JoinCounter {
+    private final File file;
+
+    public JoinCounter(BlbiLogin plugin) {
+        this.file = new File(plugin.getDataFolder(), "joincount.dat");
+        load();
+    }
+
+    public void increment() {
+        Configvar.joinCount++;
+        save();
+    }
+
+    public void load() {
+        if (file.exists()) {
+            try {
+                String content = Files.readString(file.toPath()).trim();
+                Configvar.joinCount = Integer.parseInt(content);
+            } catch (IOException | NumberFormatException e) {
+                Configvar.joinCount = 0;
+            }
+        } else {
+            Configvar.joinCount = 0;
+        }
+    }
+
+    public void save() {
+        try {
+            Files.writeString(file.toPath(), Integer.toString(Configvar.joinCount),
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+}

--- a/src/main/java/com/blbilink/blbilogin/vars/Configvar.java
+++ b/src/main/java/com/blbilink/blbilogin/vars/Configvar.java
@@ -8,12 +8,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Configvar {
 
     public static Map<String, Location> originalLocation = new HashMap<>();
     public static List<String> noLoginPlayerList = new ArrayList<>();
     public static List<String> canFlyingPlayerList = new ArrayList<>();
+    public static Set<String> vanishPlayers = new HashSet<>();
+    public static int joinCount = 0;
     public static FileConfiguration config;
     public static File configFile;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,11 @@ commands:
     description: "Kill yourself"
     aliases:
       - suicide
+  vanish:
+    description: "Toggle vanish mode"
+    permission: blbilogin.vanish
+  joinstats:
+    description: "Show join statistics"
   worldstats:
     description: "Show world statistics"
   info:


### PR DESCRIPTION
## Summary
- block usernames containing `jonarchy` from registering and kick them with a fake connection error
- track player joins via `JoinCounter`
- add admin `/vanish` command
- hide vanished players on join
- expose join counts via `/joinstats` command instead of overwriting existing `/stats`
- persist join count between restarts

## Testing
- `bash ./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684755e61180832aa3be8250e7e7c05c